### PR TITLE
fix: fix the bug where the `verified_at` timestamp is not set for sms login (PS-758)

### DIFF
--- a/selfservice/strategy/code/strategy_login_test.go
+++ b/selfservice/strategy/code/strategy_login_test.go
@@ -750,6 +750,7 @@ func TestLoginCodeStrategy(t *testing.T) {
 
 				require.NotNil(t, va)
 				require.True(t, va.Verified)
+				require.NotNil(t, va.VerifiedAt)
 			})
 
 			t.Run("suite=mfa", func(t *testing.T) {


### PR DESCRIPTION
# Description

## What? 

This fixes the bug where the `verified_at` timestamp is not set for sms login.

## Why?

Bug fix